### PR TITLE
test: add check for invalid interface ID (0xffffffff) in ERC165Checker

### DIFF
--- a/test/utils/introspection/ERC165Checker.test.js
+++ b/test/utils/introspection/ERC165Checker.test.js
@@ -242,4 +242,8 @@ describe('ERC165Checker', function () {
 
     expect(gasUsed2).to.be.lessThan(250_000n); // (2+5)*30k + 21k + some margin
   });
+
+  it("should return false for invalid interface ID 0xffffffff", async function () {
+  expect(await ERC165Checker.supportsInterface(unknown.address, "0xffffffff")).to.equal(false);
+  });
 });


### PR DESCRIPTION
This pull request adds a test case to `ERC165Checker.test.js` to ensure that `supportsInterface` correctly returns `false` when provided with the EIP-165 invalid interface ID `0xffffffff`.

This interface ID is reserved and must not be used according to the [EIP-165 specification](https://eips.ethereum.org/EIPS/eip-165).

The test ensures conformance and improves test coverage.

No related issue exists — this is a standalone contribution to improve reliability.

#### PR Checklist

- [x] Tests
- [ ] Documentation (not applicable)
- [ ] Changeset entry (not needed for tests only)
